### PR TITLE
Use Composer's CA bundle library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "issues": "https://github.com/padraic/file_get_contents/issues"
     },
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3",
+        "composer/ca-bundle": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Composer has recently extracted their CA bundle logic into a separate library ([composer/ca-bundle](https://github.com/composer/ca-bundle)). Using it fixes #8 as it falls back to a shipped CA file; the point about maintenance still remains, but I imagine if any file is going to be maintained it'd be this one.
