### PR TITLE
Update deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,13 @@
     ],
 
     "require": {
-        "php": ">=5.3",
+        "php": "^5.3 || ^7.0",
+        "ext-openssl": "*",
         "composer/ca-bundle": "^1.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.1",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
     },
 
     "autoload": {

--- a/src/Humbug/FileGetContents.php
+++ b/src/Humbug/FileGetContents.php
@@ -186,7 +186,7 @@ class FileGetContents
     }
 
     /**
-     * function copied from Composer\Util\StreamContextFactory::getContext
+     * Function copied from Composer\Util\StreamContextFactory::getContext
      *
      * This function is part of Composer.
      *
@@ -195,7 +195,7 @@ class FileGetContents
      *
      * @param string $url URL the context is to be used for
      *
-     * @throws \\RuntimeException if https proxy required and OpenSSL uninstalled
+     * @throws \RuntimeException If https proxy required and OpenSSL uninstalled
      *
      * @return resource Default context
      */

--- a/tests/Humbug/Test/FunctionTest.php
+++ b/tests/Humbug/Test/FunctionTest.php
@@ -11,10 +11,15 @@
 
 namespace Humbug\Test;
 
+use PHPUnit\Framework\TestCase;
+if (!class_exists('\PHPUnit\Framework\TestCase', true)) {
+    class_alias('\PHPUnit_Framework_TestCase', 'TestCase');
+}
+
 /**
  * @coversNothing
  */
-class FunctionTest extends \PHPUnit_Framework_TestCase
+class FunctionTest extends TestCase
 {
     private static $result;
 

--- a/tests/Humbug/Test/FunctionTest.php
+++ b/tests/Humbug/Test/FunctionTest.php
@@ -12,6 +12,7 @@
 namespace Humbug\Test;
 
 use PHPUnit\Framework\TestCase;
+
 if (!class_exists('\PHPUnit\Framework\TestCase', true)) {
     class_alias('\PHPUnit_Framework_TestCase', 'TestCase');
 }


### PR DESCRIPTION
- Change PHP constraint
- Update PHPUnit
- Delegate openssl check to Composer
- make `FileGetContents::getTlsStreamContextDefaults()` private

Regarding `FileGetContents::getTlsStreamContextDefaults()` the reason is it's more of an `init()` method in the first place and can easily be overridden in the constructor instead of overriding the method itself.