### PR TITLE
Remove Composer hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
     - composer install --no-interaction --prefer-dist
 
 script:
-    - php -d zend.enable_gc=0 bin/phpunit --coverage-text
+    - php -d zend.enable_gc=0 vendor/bin/phpunit --coverage-text
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,6 @@
         }
     },
 
-    "scripts": {
-        "post-install-cmd": "@composer bin all install --ansi",
-        "post-update-cmd": "@composer bin all update --ansi"
-    },
-
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
Seems like I was too quick to merge: those hooks make Travis fail on old builds as PHP-CS-Fixer is not compatible although not used.