### PR TITLE
Update API doc and deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,11 @@
 
     "autoload": {
         "psr-4": {
-            "Humbug\\": "src/Humbug/"
+            "Humbug\\": "src/"
         },
         "files": [
-            "src/function.php"
+            "src/function.php",
+            "src/functions.php"
         ]
     },
     "autoload-dev": {

--- a/src/FileGetContents.php
+++ b/src/FileGetContents.php
@@ -46,7 +46,7 @@ class FileGetContents
      * @param resource|array|null $context A valid context resource created with `stream_context_create()`. If you don't
      *                                     need to use a custom context, you can skip this parameter.
      *
-     * @return bool|string
+     * @return bool|string The read data or `false` on failure.
      */
     public function get($filename, $context = null)
     {
@@ -61,7 +61,7 @@ class FileGetContents
     }
 
     /**
-     * @param array $headers
+     * @param array $headers HTTP response headers.
      *
      * @final Since 1.1.0
      */
@@ -71,7 +71,7 @@ class FileGetContents
     }
 
     /**
-     * @return array|null
+     * @return array|null HTTP response headers for the last response recorded or `null` if none has been recorded.
      *
      * @final Since 1.1.0
      */

--- a/src/FileGetContents.php
+++ b/src/FileGetContents.php
@@ -306,13 +306,13 @@ class FileGetContents
             switch (parse_url($url, PHP_URL_SCHEME)) {
                 case 'http': // default request_fulluri to true
                     $reqFullUriEnv = getenv('HTTP_PROXY_REQUEST_FULLURI');
-                    if ($reqFullUriEnv === false || $reqFullUriEnv === '' || (strtolower($reqFullUriEnv) !== 'false' && (bool)$reqFullUriEnv)) {
+                    if ($reqFullUriEnv === false || $reqFullUriEnv === '' || (strtolower($reqFullUriEnv) !== 'false' && (bool) $reqFullUriEnv)) {
                         $options['http']['request_fulluri'] = true;
                     }
                     break;
                 case 'https': // default request_fulluri to true
                     $reqFullUriEnv = getenv('HTTPS_PROXY_REQUEST_FULLURI');
-                    if ($reqFullUriEnv === false || $reqFullUriEnv === '' || (strtolower($reqFullUriEnv) !== 'false' && (bool)$reqFullUriEnv)) {
+                    if ($reqFullUriEnv === false || $reqFullUriEnv === '' || (strtolower($reqFullUriEnv) !== 'false' && (bool) $reqFullUriEnv)) {
                         $options['http']['request_fulluri'] = true;
                     }
                     break;
@@ -357,6 +357,6 @@ class FileGetContents
             return !empty($contents);
         }
 
-        return (bool)openssl_x509_parse($contents);
+        return (bool) openssl_x509_parse($contents);
     }
 }

--- a/src/function.php
+++ b/src/function.php
@@ -14,6 +14,12 @@ use Humbug\FileGetContents;
 if (!function_exists('humbug_get_contents')) {
     function humbug_get_contents($filename, $use_include_path = false, $context = null)
     {
+        @trigger_error(
+            'humbug_get_contents() is deprecated since 1.1.0 and will be removed in 4.0.0. Use '
+            .'Humbug/get_contents() instead.',
+            E_USER_DEPRECATED
+        );
+
         static $fileGetContents = null;
 
         if ('https' == parse_url($filename, PHP_URL_SCHEME) && PHP_VERSION_ID < 50600) {
@@ -40,6 +46,12 @@ if (!function_exists('humbug_get_contents')) {
 if (!function_exists('humbug_get_headers')) {
     function humbug_get_headers()
     {
+        @trigger_error(
+            'humbug_get_headers() is deprecated since 1.1.0 and will be removed in 4.0.0. Use '
+            .'Humbug/get_headers() instead.',
+            E_USER_DEPRECATED
+        );
+
         return FileGetContents::getLastResponseHeaders();
     }
 }
@@ -47,6 +59,12 @@ if (!function_exists('humbug_get_headers')) {
 if (!function_exists('humbug_set_headers')) {
     function humbug_set_headers(array $headers)
     {
+        @trigger_error(
+            'humbug_set_headers() is deprecated since 1.1.0 and will be removed in 4.0.0. Use '
+            .'Humbug/get_headers() instead.',
+            E_USER_DEPRECATED
+        );
+
         FileGetContents::setNextRequestHeaders($headers);
     }
 }

--- a/src/function.php
+++ b/src/function.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Humbug\FileGetContents;
-
 if (!function_exists('humbug_get_contents')) {
     function humbug_get_contents($filename, $use_include_path = false, $context = null)
     {
@@ -20,26 +18,7 @@ if (!function_exists('humbug_get_contents')) {
             E_USER_DEPRECATED
         );
 
-        static $fileGetContents = null;
-
-        if ('https' == parse_url($filename, PHP_URL_SCHEME) && PHP_VERSION_ID < 50600) {
-            if (!isset($fileGetContents)) {
-                $fileGetContents = new FileGetContents();
-            }
-
-            return $fileGetContents->get($filename, $context);
-        } elseif (FileGetContents::hasNextRequestHeaders()) {
-            if ($context === null) {
-                $context = stream_context_create();
-            }
-            $context = FileGetContents::setHttpHeaders($context);
-        }
-        $return = file_get_contents($filename, $use_include_path, $context);
-        if (isset($http_response_header)) {
-            FileGetContents::setLastResponseHeaders($http_response_header);
-        }
-
-        return $return;
+        return Humbug\get_contents($filename, $use_include_path, $context);
     }
 }
 
@@ -52,7 +31,7 @@ if (!function_exists('humbug_get_headers')) {
             E_USER_DEPRECATED
         );
 
-        return FileGetContents::getLastResponseHeaders();
+        return Humbug\get_headers();
     }
 }
 
@@ -65,6 +44,6 @@ if (!function_exists('humbug_set_headers')) {
             E_USER_DEPRECATED
         );
 
-        FileGetContents::setNextRequestHeaders($headers);
+        Humbug\set_headers($headers);
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Humbug package.
+ *
+ * (c) 2015 Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Humbug;
+
+/**
+ * Reads entire file into a string.
+ *
+ * @param string              $filename Name of the file to read.
+ * @param bool                $use_include_path
+ * @param resource|array|null $context A valid context resource created with `stream_context_create()`. If you don't
+ *                                     need to use a custom context, you can skip this parameter.
+ *
+ * @return string|bool The function returns the read data or `false` on failure.
+ */
+function get_contents($filename, $use_include_path = false, $context = null)
+{
+    static $fileGetContents = null;
+
+    if ('https' == parse_url($filename, PHP_URL_SCHEME) && PHP_VERSION_ID < 50600) {
+        if (!isset($fileGetContents)) {
+            $fileGetContents = new FileGetContents();
+        }
+
+        return $fileGetContents->get($filename, $context);
+    } elseif (FileGetContents::hasNextRequestHeaders()) {
+        if ($context === null) {
+            $context = stream_context_create();
+        }
+
+        $context = FileGetContents::setHttpHeaders($context);
+    }
+
+    $return = file_get_contents($filename, $use_include_path, $context);
+
+    if (isset($http_response_header)) {
+        FileGetContents::setLastResponseHeaders($http_response_header);
+    }
+
+    return $return;
+}
+
+/**
+ * Fetches all the headers sent by the server in response to a HTTPS request triggered by `get_contents()`.
+ *
+ * @return array|null Returns an indexed or associative array with the headers, or `null` on failure or if no request
+ *                    has been made yet.
+ */
+function get_headers()
+{
+    return FileGetContents::getLastResponseHeaders();
+}
+
+/**
+ * @param array $headers An indexed or associative array.
+ */
+function set_headers(array $headers)
+{
+    FileGetContents::setNextRequestHeaders($headers);
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -19,7 +19,7 @@ namespace Humbug;
  * @param resource|array|null $context A valid context resource created with `stream_context_create()`. If you don't
  *                                     need to use a custom context, you can skip this parameter.
  *
- * @return string|bool The function returns the read data or `false` on failure.
+ * @return string|bool The read data or `false` on failure.
  */
 function get_contents($filename, $use_include_path = false, $context = null)
 {


### PR DESCRIPTION
- Move the functions from the global namespace to the `Humbug` namespace
- Add missing phpdoc to make the code more self-documented and laying the path for a PHP7 upgrade where we will be able to add typehints
- Try to make things private or final whenever possible