### PR TITLE
test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
     - $HOME/.composer/cache/files
 
 before_script:
-    - composer install
+    - composer install --no-progress --no-suggest
 
 script:
     - php -d zend.enable_gc=0 vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: php
 
 php:
-  - '5.3'
   - '5.4'
   - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
   - nightly
 
 matrix:
+  include:
+    - php: 5.3
+      dist: precise
   fast_finish: true
   allow_failures:
     - php: nightly
@@ -19,7 +22,7 @@ cache:
     - $HOME/.composer/cache/files
 
 before_script:
-    - composer install --no-interaction --prefer-dist
+    - composer install
 
 script:
     - php -d zend.enable_gc=0 vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
     - $HOME/.composer/cache/files
 
 before_script:
-    - composer install --no-progress --no-suggest
+    - composer install --no-interaction --prefer-dist
 
 script:
     - php -d zend.enable_gc=0 vendor/bin/phpunit --coverage-text

--- a/changelog
+++ b/changelog
@@ -1,4 +1,0 @@
-- set correct Travis CI setting
-- set the current version for PHPUnit, and PHP.
-- using the vfsStream to mock the file system.
-- add the PHP 7.2 test

--- a/changelog
+++ b/changelog
@@ -1,0 +1,4 @@
+- set correct Travis CI setting
+- set the current version for PHPUnit, and PHP.
+- using the vfsStream to mock the file system.
+- add the PHP 7.2 test

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,14 @@
     ],
 
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.3 || ^7.0 || ^7.1 || ^7.2",
         "ext-openssl": "*",
         "composer/ca-bundle": "^1.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.1",
-        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5",
+        "mikey179/vfsStream": "^1.6"
     },
 
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,7 +21,7 @@
 
     <filter>
         <whitelist>
-            <directory>./src/Humbug/</directory>
+            <directory>./src/</directory>
         </whitelist>
     </filter>
     

--- a/tests/Humbug/Test/FunctionTest.php
+++ b/tests/Humbug/Test/FunctionTest.php
@@ -12,20 +12,15 @@
 namespace Humbug\Test;
 
 use PHPUnit\Framework\TestCase;
+use org\bovigo\vfs\vfsStream;
 
-if (!class_exists('\PHPUnit\Framework\TestCase', true)) {
-    class_alias('\PHPUnit_Framework_TestCase', 'TestCase');
-}
-
-/**
- * @coversNothing
- */
 class FunctionTest extends TestCase
 {
     private static $result;
 
     public function setup()
     {
+        vfsStream::setup('home_root_path');
         if (null === self::$result) {
             $result = humbug_get_contents('https://www.howsmyssl.com/a/check');
             self::$result = json_decode($result, true);
@@ -34,7 +29,7 @@ class FunctionTest extends TestCase
 
     public function teardown()
     {
-        @unlink(sys_get_temp_dir() . '/humbug.tmp');
+        self::$result = null;
     }
 
     public function testRating()
@@ -69,8 +64,8 @@ class FunctionTest extends TestCase
 
     public function testFileGetContentsWillPassThrough()
     {
-        file_put_contents(sys_get_temp_dir() . '/humbug.tmp', ($expected = uniqid()), LOCK_EX);
-        $this->assertEquals(file_get_contents(sys_get_temp_dir() . '/humbug.tmp'), $expected);
+        file_put_contents(vfsStream::url('home_root_path/humbug.tmp'), ($expected = uniqid()));
+        $this->assertEquals(file_get_contents(vfsStream::url('home_root_path/humbug.tmp')), $expected);
     }
 
     public function testCanGetResponseHeaders()


### PR DESCRIPTION
# Changed log
- set correct Travis CI setting
- set the current version for PHPUnit, and PHP.
- using the vfsStream to mock the file system.
- add the PHP 7.2 test
- according to this [issue](https://github.com/travis-ci/travis-ci/issues/7163), the PHP 5.3 should set the precise dist when doing Travis CI build.